### PR TITLE
Updates to support adding attributes in Javascript only

### DIFF
--- a/tessera_client/api/_version.py
+++ b/tessera_client/api/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 4, 2)
+__version_info__ = (0, 4, 3)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
This removes `GenericDashboardItem` and merges its functionality of
handling  and storing arbitrary attributes to the base `DashboardItem`
class.

This allows the dashboard items which are modeled in python to be
extended with new attributes purely by modifying the Javascript code in
tessera, which can already be done with all of the items that mapped to
`GenericDashboardItem`.

This required coding all the existing keys (ones with named args in
constructors) explicitly, which is less than ideal.

I’m still halfway tempted to dump the entire python model, but it’s
nice to have at least _some_ validation for the API to use.

Meh.