### PR TITLE
drop simplejson requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests==2.3.0
-simplejson==3.5.2


### PR DESCRIPTION
it isn't imported directly and shipped with python >= 2.6